### PR TITLE
Comment out all GType functions

### DIFF
--- a/src/array-builder.jl
+++ b/src/array-builder.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_array_builder_get_type()
-    ccall((:garrow_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_array_builder_get_type()
+#     ccall((:garrow_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowArrayBuilder(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowArrayBuilder, libarrowglib), Cvoid, (Ptr{Ptr{GArrowArrayBuilder}},), _ptr)
@@ -46,9 +46,9 @@ function garrow_array_builder_finish(builder, error)
     ccall((:garrow_array_builder_finish, libarrowglib), Ptr{GArrowArray}, (Ptr{GArrowArrayBuilder}, Ptr{Ptr{GError}}), builder, error)
 end
 
-function garrow_boolean_array_builder_get_type()
-    ccall((:garrow_boolean_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_boolean_array_builder_get_type()
+#     ccall((:garrow_boolean_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_boolean_array_builder_new()
     ccall((:garrow_boolean_array_builder_new, libarrowglib), Ptr{GArrowBooleanArrayBuilder}, ())
@@ -70,9 +70,9 @@ function garrow_boolean_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_boolean_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowBooleanArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_int_array_builder_get_type()
-    ccall((:garrow_int_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_int_array_builder_get_type()
+#     ccall((:garrow_int_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_int_array_builder_new()
     ccall((:garrow_int_array_builder_new, libarrowglib), Ptr{GArrowIntArrayBuilder}, ())
@@ -94,9 +94,9 @@ function garrow_int_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_int_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowIntArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_uint_array_builder_get_type()
-    ccall((:garrow_uint_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint_array_builder_get_type()
+#     ccall((:garrow_uint_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUIntArrayBuilder(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUIntArrayBuilder, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUIntArrayBuilder}},), _ptr)
@@ -142,9 +142,9 @@ function garrow_uint_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_uint_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowUIntArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_int8_array_builder_get_type()
-    ccall((:garrow_int8_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_int8_array_builder_get_type()
+#     ccall((:garrow_int8_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_int8_array_builder_new()
     ccall((:garrow_int8_array_builder_new, libarrowglib), Ptr{GArrowInt8ArrayBuilder}, ())
@@ -166,9 +166,9 @@ function garrow_int8_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_int8_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowInt8ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_uint8_array_builder_get_type()
-    ccall((:garrow_uint8_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint8_array_builder_get_type()
+#     ccall((:garrow_uint8_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_uint8_array_builder_new()
     ccall((:garrow_uint8_array_builder_new, libarrowglib), Ptr{GArrowUInt8ArrayBuilder}, ())
@@ -190,9 +190,9 @@ function garrow_uint8_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_uint8_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowUInt8ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_int16_array_builder_get_type()
-    ccall((:garrow_int16_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_int16_array_builder_get_type()
+#     ccall((:garrow_int16_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_int16_array_builder_new()
     ccall((:garrow_int16_array_builder_new, libarrowglib), Ptr{GArrowInt16ArrayBuilder}, ())
@@ -214,9 +214,9 @@ function garrow_int16_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_int16_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowInt16ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_uint16_array_builder_get_type()
-    ccall((:garrow_uint16_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint16_array_builder_get_type()
+#     ccall((:garrow_uint16_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_uint16_array_builder_new()
     ccall((:garrow_uint16_array_builder_new, libarrowglib), Ptr{GArrowUInt16ArrayBuilder}, ())
@@ -238,9 +238,9 @@ function garrow_uint16_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_uint16_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowUInt16ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_int32_array_builder_get_type()
-    ccall((:garrow_int32_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_int32_array_builder_get_type()
+#     ccall((:garrow_int32_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_int32_array_builder_new()
     ccall((:garrow_int32_array_builder_new, libarrowglib), Ptr{GArrowInt32ArrayBuilder}, ())
@@ -262,9 +262,9 @@ function garrow_int32_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_int32_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowInt32ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_uint32_array_builder_get_type()
-    ccall((:garrow_uint32_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint32_array_builder_get_type()
+#     ccall((:garrow_uint32_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_uint32_array_builder_new()
     ccall((:garrow_uint32_array_builder_new, libarrowglib), Ptr{GArrowUInt32ArrayBuilder}, ())
@@ -286,9 +286,9 @@ function garrow_uint32_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_uint32_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowUInt32ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_int64_array_builder_get_type()
-    ccall((:garrow_int64_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_int64_array_builder_get_type()
+#     ccall((:garrow_int64_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_int64_array_builder_new()
     ccall((:garrow_int64_array_builder_new, libarrowglib), Ptr{GArrowInt64ArrayBuilder}, ())
@@ -310,9 +310,9 @@ function garrow_int64_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_int64_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowInt64ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_uint64_array_builder_get_type()
-    ccall((:garrow_uint64_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint64_array_builder_get_type()
+#     ccall((:garrow_uint64_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_uint64_array_builder_new()
     ccall((:garrow_uint64_array_builder_new, libarrowglib), Ptr{GArrowUInt64ArrayBuilder}, ())
@@ -334,9 +334,9 @@ function garrow_uint64_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_uint64_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowUInt64ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_float_array_builder_get_type()
-    ccall((:garrow_float_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_float_array_builder_get_type()
+#     ccall((:garrow_float_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_float_array_builder_new()
     ccall((:garrow_float_array_builder_new, libarrowglib), Ptr{GArrowFloatArrayBuilder}, ())
@@ -358,9 +358,9 @@ function garrow_float_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_float_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowFloatArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_double_array_builder_get_type()
-    ccall((:garrow_double_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_double_array_builder_get_type()
+#     ccall((:garrow_double_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_double_array_builder_new()
     ccall((:garrow_double_array_builder_new, libarrowglib), Ptr{GArrowDoubleArrayBuilder}, ())
@@ -382,9 +382,9 @@ function garrow_double_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_double_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowDoubleArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_binary_array_builder_get_type()
-    ccall((:garrow_binary_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_binary_array_builder_get_type()
+#     ccall((:garrow_binary_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_binary_array_builder_new()
     ccall((:garrow_binary_array_builder_new, libarrowglib), Ptr{GArrowBinaryArrayBuilder}, ())
@@ -398,9 +398,9 @@ function garrow_binary_array_builder_append_null(builder, error)
     ccall((:garrow_binary_array_builder_append_null, libarrowglib), gboolean, (Ptr{GArrowBinaryArrayBuilder}, Ptr{Ptr{GError}}), builder, error)
 end
 
-function garrow_string_array_builder_get_type()
-    ccall((:garrow_string_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_string_array_builder_get_type()
+#     ccall((:garrow_string_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_string_array_builder_new()
     ccall((:garrow_string_array_builder_new, libarrowglib), Ptr{GArrowStringArrayBuilder}, ())
@@ -414,9 +414,9 @@ function garrow_string_array_builder_append_values(builder, values, values_lengt
     ccall((:garrow_string_array_builder_append_values, libarrowglib), gboolean, (Ptr{GArrowStringArrayBuilder}, Ptr{Ptr{gchar}}, gint64, Ptr{gboolean}, gint64, Ptr{Ptr{GError}}), builder, values, values_length, is_valids, is_valids_length, error)
 end
 
-function garrow_date32_array_builder_get_type()
-    ccall((:garrow_date32_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_date32_array_builder_get_type()
+#     ccall((:garrow_date32_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_date32_array_builder_new()
     ccall((:garrow_date32_array_builder_new, libarrowglib), Ptr{GArrowDate32ArrayBuilder}, ())
@@ -438,9 +438,9 @@ function garrow_date32_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_date32_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowDate32ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_date64_array_builder_get_type()
-    ccall((:garrow_date64_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_date64_array_builder_get_type()
+#     ccall((:garrow_date64_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_date64_array_builder_new()
     ccall((:garrow_date64_array_builder_new, libarrowglib), Ptr{GArrowDate64ArrayBuilder}, ())
@@ -462,9 +462,9 @@ function garrow_date64_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_date64_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowDate64ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_timestamp_array_builder_get_type()
-    ccall((:garrow_timestamp_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_timestamp_array_builder_get_type()
+#     ccall((:garrow_timestamp_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_timestamp_array_builder_new(data_type)
     ccall((:garrow_timestamp_array_builder_new, libarrowglib), Ptr{GArrowTimestampArrayBuilder}, (Ptr{GArrowTimestampDataType},), data_type)
@@ -486,9 +486,9 @@ function garrow_timestamp_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_timestamp_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowTimestampArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_time32_array_builder_get_type()
-    ccall((:garrow_time32_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_time32_array_builder_get_type()
+#     ccall((:garrow_time32_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_time32_array_builder_new(data_type)
     ccall((:garrow_time32_array_builder_new, libarrowglib), Ptr{GArrowTime32ArrayBuilder}, (Ptr{GArrowTime32DataType},), data_type)
@@ -510,9 +510,9 @@ function garrow_time32_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_time32_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowTime32ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_time64_array_builder_get_type()
-    ccall((:garrow_time64_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_time64_array_builder_get_type()
+#     ccall((:garrow_time64_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_time64_array_builder_new(data_type)
     ccall((:garrow_time64_array_builder_new, libarrowglib), Ptr{GArrowTime64ArrayBuilder}, (Ptr{GArrowTime64DataType},), data_type)
@@ -534,9 +534,9 @@ function garrow_time64_array_builder_append_nulls(builder, n::gint64, error)
     ccall((:garrow_time64_array_builder_append_nulls, libarrowglib), gboolean, (Ptr{GArrowTime64ArrayBuilder}, gint64, Ptr{Ptr{GError}}), builder, n, error)
 end
 
-function garrow_list_array_builder_get_type()
-    ccall((:garrow_list_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_list_array_builder_get_type()
+#     ccall((:garrow_list_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_list_array_builder_new(data_type, error)
     ccall((:garrow_list_array_builder_new, libarrowglib), Ptr{GArrowListArrayBuilder}, (Ptr{GArrowListDataType}, Ptr{Ptr{GError}}), data_type, error)
@@ -554,9 +554,9 @@ function garrow_list_array_builder_get_value_builder(builder)
     ccall((:garrow_list_array_builder_get_value_builder, libarrowglib), Ptr{GArrowArrayBuilder}, (Ptr{GArrowListArrayBuilder},), builder)
 end
 
-function garrow_struct_array_builder_get_type()
-    ccall((:garrow_struct_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_struct_array_builder_get_type()
+#     ccall((:garrow_struct_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_struct_array_builder_new(data_type, error)
     ccall((:garrow_struct_array_builder_new, libarrowglib), Ptr{GArrowStructArrayBuilder}, (Ptr{GArrowStructDataType}, Ptr{Ptr{GError}}), data_type, error)
@@ -578,9 +578,9 @@ function garrow_struct_array_builder_get_field_builders(builder)
     ccall((:garrow_struct_array_builder_get_field_builders, libarrowglib), Ptr{GList}, (Ptr{GArrowStructArrayBuilder},), builder)
 end
 
-function garrow_decimal128_array_builder_get_type()
-    ccall((:garrow_decimal128_array_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_decimal128_array_builder_get_type()
+#     ccall((:garrow_decimal128_array_builder_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDecimal128ArrayBuilder(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDecimal128ArrayBuilder, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDecimal128ArrayBuilder}},), _ptr)

--- a/src/basic-array.jl
+++ b/src/basic-array.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_array_get_type()
-    ccall((:garrow_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_array_get_type()
+#     ccall((:garrow_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowArray}},), _ptr)
@@ -94,17 +94,17 @@ function garrow_array_dictionary_encode(array, error)
     ccall((:garrow_array_dictionary_encode, libarrowglib), Ptr{GArrowArray}, (Ptr{GArrowArray}, Ptr{Ptr{GError}}), array, error)
 end
 
-function garrow_null_array_get_type()
-    ccall((:garrow_null_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_null_array_get_type()
+#     ccall((:garrow_null_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_null_array_new(length::gint64)
     ccall((:garrow_null_array_new, libarrowglib), Ptr{GArrowNullArray}, (gint64,), length)
 end
 
-function garrow_primitive_array_get_type()
-    ccall((:garrow_primitive_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_primitive_array_get_type()
+#     ccall((:garrow_primitive_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowPrimitiveArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowPrimitiveArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowPrimitiveArray}},), _ptr)
@@ -134,9 +134,9 @@ function garrow_primitive_array_get_buffer(array)
     ccall((:garrow_primitive_array_get_buffer, libarrowglib), Ptr{GArrowBuffer}, (Ptr{GArrowPrimitiveArray},), array)
 end
 
-function garrow_boolean_array_get_type()
-    ccall((:garrow_boolean_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_boolean_array_get_type()
+#     ccall((:garrow_boolean_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_boolean_array_new(length::gint64, data, null_bitmap, n_nulls::gint64)
     ccall((:garrow_boolean_array_new, libarrowglib), Ptr{GArrowBooleanArray}, (gint64, Ptr{GArrowBuffer}, Ptr{GArrowBuffer}, gint64), length, data, null_bitmap, n_nulls)
@@ -150,9 +150,9 @@ function garrow_boolean_array_get_values(array, length)
     ccall((:garrow_boolean_array_get_values, libarrowglib), Ptr{gboolean}, (Ptr{GArrowBooleanArray}, Ptr{gint64}), array, length)
 end
 
-function garrow_numeric_array_get_type()
-    ccall((:garrow_numeric_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_numeric_array_get_type()
+#     ccall((:garrow_numeric_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowNumericArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowNumericArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowNumericArray}},), _ptr)
@@ -178,9 +178,9 @@ function GARROW_NUMERIC_ARRAY_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_NUMERIC_ARRAY_GET_CLASS, libarrowglib), Ptr{GArrowNumericArrayClass}, (gpointer,), ptr)
 end
 
-function garrow_int8_array_get_type()
-    ccall((:garrow_int8_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_int8_array_get_type()
+#     ccall((:garrow_int8_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt8Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt8Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt8Array}},), _ptr)
@@ -218,9 +218,9 @@ function garrow_int8_array_get_values(array, length)
     ccall((:garrow_int8_array_get_values, libarrowglib), Ptr{gint8}, (Ptr{GArrowInt8Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_uint8_array_get_type()
-    ccall((:garrow_uint8_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint8_array_get_type()
+#     ccall((:garrow_uint8_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt8Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt8Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt8Array}},), _ptr)
@@ -258,9 +258,9 @@ function garrow_uint8_array_get_values(array, length)
     ccall((:garrow_uint8_array_get_values, libarrowglib), Ptr{guint8}, (Ptr{GArrowUInt8Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_int16_array_get_type()
-    ccall((:garrow_int16_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_int16_array_get_type()
+#     ccall((:garrow_int16_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt16Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt16Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt16Array}},), _ptr)
@@ -298,9 +298,9 @@ function garrow_int16_array_get_values(array, length)
     ccall((:garrow_int16_array_get_values, libarrowglib), Ptr{gint16}, (Ptr{GArrowInt16Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_uint16_array_get_type()
-    ccall((:garrow_uint16_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint16_array_get_type()
+#     ccall((:garrow_uint16_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt16Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt16Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt16Array}},), _ptr)
@@ -338,9 +338,9 @@ function garrow_uint16_array_get_values(array, length)
     ccall((:garrow_uint16_array_get_values, libarrowglib), Ptr{guint16}, (Ptr{GArrowUInt16Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_int32_array_get_type()
-    ccall((:garrow_int32_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_int32_array_get_type()
+#     ccall((:garrow_int32_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt32Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt32Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt32Array}},), _ptr)
@@ -378,9 +378,9 @@ function garrow_int32_array_get_values(array, length)
     ccall((:garrow_int32_array_get_values, libarrowglib), Ptr{gint32}, (Ptr{GArrowInt32Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_uint32_array_get_type()
-    ccall((:garrow_uint32_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint32_array_get_type()
+#     ccall((:garrow_uint32_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt32Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt32Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt32Array}},), _ptr)
@@ -418,9 +418,9 @@ function garrow_uint32_array_get_values(array, length)
     ccall((:garrow_uint32_array_get_values, libarrowglib), Ptr{guint32}, (Ptr{GArrowUInt32Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_int64_array_get_type()
-    ccall((:garrow_int64_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_int64_array_get_type()
+#     ccall((:garrow_int64_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt64Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt64Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt64Array}},), _ptr)
@@ -458,9 +458,9 @@ function garrow_int64_array_get_values(array, length)
     ccall((:garrow_int64_array_get_values, libarrowglib), Ptr{gint64}, (Ptr{GArrowInt64Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_uint64_array_get_type()
-    ccall((:garrow_uint64_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint64_array_get_type()
+#     ccall((:garrow_uint64_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt64Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt64Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt64Array}},), _ptr)
@@ -498,9 +498,9 @@ function garrow_uint64_array_get_values(array, length)
     ccall((:garrow_uint64_array_get_values, libarrowglib), Ptr{guint64}, (Ptr{GArrowUInt64Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_float_array_get_type()
-    ccall((:garrow_float_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_float_array_get_type()
+#     ccall((:garrow_float_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowFloatArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowFloatArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowFloatArray}},), _ptr)
@@ -538,9 +538,9 @@ function garrow_float_array_get_values(array, length)
     ccall((:garrow_float_array_get_values, libarrowglib), Ptr{gfloat}, (Ptr{GArrowFloatArray}, Ptr{gint64}), array, length)
 end
 
-function garrow_double_array_get_type()
-    ccall((:garrow_double_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_double_array_get_type()
+#     ccall((:garrow_double_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDoubleArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDoubleArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDoubleArray}},), _ptr)
@@ -578,9 +578,9 @@ function garrow_double_array_get_values(array, length)
     ccall((:garrow_double_array_get_values, libarrowglib), Ptr{gdouble}, (Ptr{GArrowDoubleArray}, Ptr{gint64}), array, length)
 end
 
-function garrow_binary_array_get_type()
-    ccall((:garrow_binary_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_binary_array_get_type()
+#     ccall((:garrow_binary_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_binary_array_new(length::gint64, value_offsets, data, null_bitmap, n_nulls::gint64)
     ccall((:garrow_binary_array_new, libarrowglib), Ptr{GArrowBinaryArray}, (gint64, Ptr{GArrowBuffer}, Ptr{GArrowBuffer}, Ptr{GArrowBuffer}, gint64), length, value_offsets, data, null_bitmap, n_nulls)
@@ -598,9 +598,9 @@ function garrow_binary_array_get_offsets_buffer(array)
     ccall((:garrow_binary_array_get_offsets_buffer, libarrowglib), Ptr{GArrowBuffer}, (Ptr{GArrowBinaryArray},), array)
 end
 
-function garrow_string_array_get_type()
-    ccall((:garrow_string_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_string_array_get_type()
+#     ccall((:garrow_string_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_string_array_new(length::gint64, value_offsets, data, null_bitmap, n_nulls::gint64)
     ccall((:garrow_string_array_new, libarrowglib), Ptr{GArrowStringArray}, (gint64, Ptr{GArrowBuffer}, Ptr{GArrowBuffer}, Ptr{GArrowBuffer}, gint64), length, value_offsets, data, null_bitmap, n_nulls)
@@ -610,9 +610,9 @@ function garrow_string_array_get_string(array, i::gint64)
     ccall((:garrow_string_array_get_string, libarrowglib), Ptr{gchar}, (Ptr{GArrowStringArray}, gint64), array, i)
 end
 
-function garrow_date32_array_get_type()
-    ccall((:garrow_date32_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_date32_array_get_type()
+#     ccall((:garrow_date32_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDate32Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDate32Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDate32Array}},), _ptr)
@@ -650,9 +650,9 @@ function garrow_date32_array_get_values(array, length)
     ccall((:garrow_date32_array_get_values, libarrowglib), Ptr{gint32}, (Ptr{GArrowDate32Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_date64_array_get_type()
-    ccall((:garrow_date64_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_date64_array_get_type()
+#     ccall((:garrow_date64_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDate64Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDate64Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDate64Array}},), _ptr)
@@ -690,9 +690,9 @@ function garrow_date64_array_get_values(array, length)
     ccall((:garrow_date64_array_get_values, libarrowglib), Ptr{gint64}, (Ptr{GArrowDate64Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_timestamp_array_get_type()
-    ccall((:garrow_timestamp_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_timestamp_array_get_type()
+#     ccall((:garrow_timestamp_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowTimestampArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowTimestampArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowTimestampArray}},), _ptr)
@@ -730,9 +730,9 @@ function garrow_timestamp_array_get_values(array, length)
     ccall((:garrow_timestamp_array_get_values, libarrowglib), Ptr{gint64}, (Ptr{GArrowTimestampArray}, Ptr{gint64}), array, length)
 end
 
-function garrow_time32_array_get_type()
-    ccall((:garrow_time32_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_time32_array_get_type()
+#     ccall((:garrow_time32_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowTime32Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowTime32Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowTime32Array}},), _ptr)
@@ -770,9 +770,9 @@ function garrow_time32_array_get_values(array, length)
     ccall((:garrow_time32_array_get_values, libarrowglib), Ptr{gint32}, (Ptr{GArrowTime32Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_time64_array_get_type()
-    ccall((:garrow_time64_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_time64_array_get_type()
+#     ccall((:garrow_time64_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowTime64Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowTime64Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowTime64Array}},), _ptr)
@@ -810,9 +810,9 @@ function garrow_time64_array_get_values(array, length)
     ccall((:garrow_time64_array_get_values, libarrowglib), Ptr{gint64}, (Ptr{GArrowTime64Array}, Ptr{gint64}), array, length)
 end
 
-function garrow_fixed_size_binary_array_get_type()
-    ccall((:garrow_fixed_size_binary_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_fixed_size_binary_array_get_type()
+#     ccall((:garrow_fixed_size_binary_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowFixedSizeBinaryArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowFixedSizeBinaryArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowFixedSizeBinaryArray}},), _ptr)
@@ -838,9 +838,9 @@ function GARROW_FIXED_SIZE_BINARY_ARRAY_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_FIXED_SIZE_BINARY_ARRAY_GET_CLASS, libarrowglib), Ptr{GArrowFixedSizeBinaryArrayClass}, (gpointer,), ptr)
 end
 
-function garrow_decimal128_array_get_type()
-    ccall((:garrow_decimal128_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_decimal128_array_get_type()
+#     ccall((:garrow_decimal128_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDecimal128Array(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDecimal128Array, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDecimal128Array}},), _ptr)

--- a/src/basic-data-type.jl
+++ b/src/basic-data-type.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_data_type_get_type()
-    ccall((:garrow_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_data_type_get_type()
+#     ccall((:garrow_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDataType}},), _ptr)
@@ -42,9 +42,9 @@ function garrow_data_type_get_id(data_type)
     ccall((:garrow_data_type_get_id, libarrowglib), GArrowType, (Ptr{GArrowDataType},), data_type)
 end
 
-function garrow_fixed_width_data_type_get_type()
-    ccall((:garrow_fixed_width_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_fixed_width_data_type_get_type()
+#     ccall((:garrow_fixed_width_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowFixedWidthDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowFixedWidthDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowFixedWidthDataType}},), _ptr)
@@ -74,17 +74,17 @@ function garrow_fixed_width_data_type_get_bit_width(data_type)
     ccall((:garrow_fixed_width_data_type_get_bit_width, libarrowglib), gint, (Ptr{GArrowFixedWidthDataType},), data_type)
 end
 
-function garrow_null_data_type_get_type()
-    ccall((:garrow_null_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_null_data_type_get_type()
+#     ccall((:garrow_null_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_null_data_type_new()
     ccall((:garrow_null_data_type_new, libarrowglib), Ptr{GArrowNullDataType}, ())
 end
 
-function garrow_boolean_data_type_get_type()
-    ccall((:garrow_boolean_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_boolean_data_type_get_type()
+#     ccall((:garrow_boolean_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowBooleanDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowBooleanDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowBooleanDataType}},), _ptr)
@@ -114,9 +114,9 @@ function garrow_boolean_data_type_new()
     ccall((:garrow_boolean_data_type_new, libarrowglib), Ptr{GArrowBooleanDataType}, ())
 end
 
-function garrow_numeric_data_type_get_type()
-    ccall((:garrow_numeric_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_numeric_data_type_get_type()
+#     ccall((:garrow_numeric_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowNumericDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowNumericDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowNumericDataType}},), _ptr)
@@ -142,9 +142,9 @@ function GARROW_NUMERIC_DATA_TYPE_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_NUMERIC_DATA_TYPE_GET_CLASS, libarrowglib), Ptr{GArrowNumericDataTypeClass}, (gpointer,), ptr)
 end
 
-function garrow_integer_data_type_get_type()
-    ccall((:garrow_integer_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_integer_data_type_get_type()
+#     ccall((:garrow_integer_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowIntegerDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowIntegerDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowIntegerDataType}},), _ptr)
@@ -170,9 +170,9 @@ function GARROW_INTEGER_DATA_TYPE_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_INTEGER_DATA_TYPE_GET_CLASS, libarrowglib), Ptr{GArrowIntegerDataTypeClass}, (gpointer,), ptr)
 end
 
-function garrow_int8_data_type_get_type()
-    ccall((:garrow_int8_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_int8_data_type_get_type()
+#     ccall((:garrow_int8_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt8DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt8DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt8DataType}},), _ptr)
@@ -202,9 +202,9 @@ function garrow_int8_data_type_new()
     ccall((:garrow_int8_data_type_new, libarrowglib), Ptr{GArrowInt8DataType}, ())
 end
 
-function garrow_uint8_data_type_get_type()
-    ccall((:garrow_uint8_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint8_data_type_get_type()
+#     ccall((:garrow_uint8_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt8DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt8DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt8DataType}},), _ptr)
@@ -234,9 +234,9 @@ function garrow_uint8_data_type_new()
     ccall((:garrow_uint8_data_type_new, libarrowglib), Ptr{GArrowUInt8DataType}, ())
 end
 
-function garrow_int16_data_type_get_type()
-    ccall((:garrow_int16_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_int16_data_type_get_type()
+#     ccall((:garrow_int16_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt16DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt16DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt16DataType}},), _ptr)
@@ -266,9 +266,9 @@ function garrow_int16_data_type_new()
     ccall((:garrow_int16_data_type_new, libarrowglib), Ptr{GArrowInt16DataType}, ())
 end
 
-function garrow_uint16_data_type_get_type()
-    ccall((:garrow_uint16_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint16_data_type_get_type()
+#     ccall((:garrow_uint16_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt16DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt16DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt16DataType}},), _ptr)
@@ -298,9 +298,9 @@ function garrow_uint16_data_type_new()
     ccall((:garrow_uint16_data_type_new, libarrowglib), Ptr{GArrowUInt16DataType}, ())
 end
 
-function garrow_int32_data_type_get_type()
-    ccall((:garrow_int32_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_int32_data_type_get_type()
+#     ccall((:garrow_int32_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt32DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt32DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt32DataType}},), _ptr)
@@ -330,9 +330,9 @@ function garrow_int32_data_type_new()
     ccall((:garrow_int32_data_type_new, libarrowglib), Ptr{GArrowInt32DataType}, ())
 end
 
-function garrow_uint32_data_type_get_type()
-    ccall((:garrow_uint32_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint32_data_type_get_type()
+#     ccall((:garrow_uint32_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt32DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt32DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt32DataType}},), _ptr)
@@ -362,9 +362,9 @@ function garrow_uint32_data_type_new()
     ccall((:garrow_uint32_data_type_new, libarrowglib), Ptr{GArrowUInt32DataType}, ())
 end
 
-function garrow_int64_data_type_get_type()
-    ccall((:garrow_int64_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_int64_data_type_get_type()
+#     ccall((:garrow_int64_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInt64DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInt64DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInt64DataType}},), _ptr)
@@ -394,9 +394,9 @@ function garrow_int64_data_type_new()
     ccall((:garrow_int64_data_type_new, libarrowglib), Ptr{GArrowInt64DataType}, ())
 end
 
-function garrow_uint64_data_type_get_type()
-    ccall((:garrow_uint64_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_uint64_data_type_get_type()
+#     ccall((:garrow_uint64_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowUInt64DataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowUInt64DataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowUInt64DataType}},), _ptr)
@@ -426,9 +426,9 @@ function garrow_uint64_data_type_new()
     ccall((:garrow_uint64_data_type_new, libarrowglib), Ptr{GArrowUInt64DataType}, ())
 end
 
-function garrow_floating_point_data_type_get_type()
-    ccall((:garrow_floating_point_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_floating_point_data_type_get_type()
+#     ccall((:garrow_floating_point_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowFloatingPointDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowFloatingPointDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowFloatingPointDataType}},), _ptr)
@@ -454,9 +454,9 @@ function GARROW_FLOATING_POINT_DATA_TYPE_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_FLOATING_POINT_DATA_TYPE_GET_CLASS, libarrowglib), Ptr{GArrowFloatingPointDataTypeClass}, (gpointer,), ptr)
 end
 
-function garrow_float_data_type_get_type()
-    ccall((:garrow_float_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_float_data_type_get_type()
+#     ccall((:garrow_float_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowFloatDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowFloatDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowFloatDataType}},), _ptr)
@@ -486,9 +486,9 @@ function garrow_float_data_type_new()
     ccall((:garrow_float_data_type_new, libarrowglib), Ptr{GArrowFloatDataType}, ())
 end
 
-function garrow_double_data_type_get_type()
-    ccall((:garrow_double_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_double_data_type_get_type()
+#     ccall((:garrow_double_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDoubleDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDoubleDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDoubleDataType}},), _ptr)
@@ -518,41 +518,41 @@ function garrow_double_data_type_new()
     ccall((:garrow_double_data_type_new, libarrowglib), Ptr{GArrowDoubleDataType}, ())
 end
 
-function garrow_binary_data_type_get_type()
-    ccall((:garrow_binary_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_binary_data_type_get_type()
+#     ccall((:garrow_binary_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_binary_data_type_new()
     ccall((:garrow_binary_data_type_new, libarrowglib), Ptr{GArrowBinaryDataType}, ())
 end
 
-function garrow_string_data_type_get_type()
-    ccall((:garrow_string_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_string_data_type_get_type()
+#     ccall((:garrow_string_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_string_data_type_new()
     ccall((:garrow_string_data_type_new, libarrowglib), Ptr{GArrowStringDataType}, ())
 end
 
-function garrow_date32_data_type_get_type()
-    ccall((:garrow_date32_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_date32_data_type_get_type()
+#     ccall((:garrow_date32_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_date32_data_type_new()
     ccall((:garrow_date32_data_type_new, libarrowglib), Ptr{GArrowDate32DataType}, ())
 end
 
-function garrow_date64_data_type_get_type()
-    ccall((:garrow_date64_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_date64_data_type_get_type()
+#     ccall((:garrow_date64_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_date64_data_type_new()
     ccall((:garrow_date64_data_type_new, libarrowglib), Ptr{GArrowDate64DataType}, ())
 end
 
-function garrow_timestamp_data_type_get_type()
-    ccall((:garrow_timestamp_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_timestamp_data_type_get_type()
+#     ccall((:garrow_timestamp_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_timestamp_data_type_new(unit::GArrowTimeUnit)
     ccall((:garrow_timestamp_data_type_new, libarrowglib), Ptr{GArrowTimestampDataType}, (GArrowTimeUnit,), unit)
@@ -562,33 +562,33 @@ function garrow_timestamp_data_type_get_unit(timestamp_data_type)
     ccall((:garrow_timestamp_data_type_get_unit, libarrowglib), GArrowTimeUnit, (Ptr{GArrowTimestampDataType},), timestamp_data_type)
 end
 
-function garrow_time_data_type_get_type()
-    ccall((:garrow_time_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_time_data_type_get_type()
+#     ccall((:garrow_time_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_time_data_type_get_unit(time_data_type)
     ccall((:garrow_time_data_type_get_unit, libarrowglib), GArrowTimeUnit, (Ptr{GArrowTimeDataType},), time_data_type)
 end
 
-function garrow_time32_data_type_get_type()
-    ccall((:garrow_time32_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_time32_data_type_get_type()
+#     ccall((:garrow_time32_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_time32_data_type_new(unit::GArrowTimeUnit, error)
     ccall((:garrow_time32_data_type_new, libarrowglib), Ptr{GArrowTime32DataType}, (GArrowTimeUnit, Ptr{Ptr{GError}}), unit, error)
 end
 
-function garrow_time64_data_type_get_type()
-    ccall((:garrow_time64_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_time64_data_type_get_type()
+#     ccall((:garrow_time64_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_time64_data_type_new(unit::GArrowTimeUnit, error)
     ccall((:garrow_time64_data_type_new, libarrowglib), Ptr{GArrowTime64DataType}, (GArrowTimeUnit, Ptr{Ptr{GError}}), unit, error)
 end
 
-function garrow_decimal_data_type_get_type()
-    ccall((:garrow_decimal_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_decimal_data_type_get_type()
+#     ccall((:garrow_decimal_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDecimalDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDecimalDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDecimalDataType}},), _ptr)

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_buffer_get_type()
-    ccall((:garrow_buffer_get_type, libarrowglib), GType, ())
-end
+# function garrow_buffer_get_type()
+#     ccall((:garrow_buffer_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowBuffer(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowBuffer, libarrowglib), Cvoid, (Ptr{Ptr{GArrowBuffer}},), _ptr)
@@ -78,9 +78,9 @@ function garrow_buffer_slice(buffer, offset::gint64, size::gint64)
     ccall((:garrow_buffer_slice, libarrowglib), Ptr{GArrowBuffer}, (Ptr{GArrowBuffer}, gint64, gint64), buffer, offset, size)
 end
 
-function garrow_mutable_buffer_get_type()
-    ccall((:garrow_mutable_buffer_get_type, libarrowglib), GType, ())
-end
+# function garrow_mutable_buffer_get_type()
+#     ccall((:garrow_mutable_buffer_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowMutableBuffer(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowMutableBuffer, libarrowglib), Cvoid, (Ptr{Ptr{GArrowMutableBuffer}},), _ptr)
@@ -118,9 +118,9 @@ function garrow_mutable_buffer_slice(buffer, offset::gint64, size::gint64)
     ccall((:garrow_mutable_buffer_slice, libarrowglib), Ptr{GArrowMutableBuffer}, (Ptr{GArrowMutableBuffer}, gint64, gint64), buffer, offset, size)
 end
 
-function garrow_resizable_buffer_get_type()
-    ccall((:garrow_resizable_buffer_get_type, libarrowglib), GType, ())
-end
+# function garrow_resizable_buffer_get_type()
+#     ccall((:garrow_resizable_buffer_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowResizableBuffer(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowResizableBuffer, libarrowglib), Cvoid, (Ptr{Ptr{GArrowResizableBuffer}},), _ptr)

--- a/src/chunked-array.jl
+++ b/src/chunked-array.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_chunked_array_get_type()
-    ccall((:garrow_chunked_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_chunked_array_get_type()
+#     ccall((:garrow_chunked_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_chunked_array_new(chunks)
     ccall((:garrow_chunked_array_new, libarrowglib), Ptr{GArrowChunkedArray}, (Ptr{GList},), chunks)

--- a/src/column.jl
+++ b/src/column.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_column_get_type()
-    ccall((:garrow_column_get_type, libarrowglib), GType, ())
-end
+# function garrow_column_get_type()
+#     ccall((:garrow_column_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_column_new_array(field, array)
     ccall((:garrow_column_new_array, libarrowglib), Ptr{GArrowColumn}, (Ptr{GArrowField}, Ptr{GArrowArray}), field, array)

--- a/src/composite-array.jl
+++ b/src/composite-array.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_list_array_get_type()
-    ccall((:garrow_list_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_list_array_get_type()
+#     ccall((:garrow_list_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_list_array_new(length::gint64, value_offsets, values, null_bitmap, n_nulls::gint64)
     ccall((:garrow_list_array_new, libarrowglib), Ptr{GArrowListArray}, (gint64, Ptr{GArrowBuffer}, Ptr{GArrowArray}, Ptr{GArrowBuffer}, gint64), length, value_offsets, values, null_bitmap, n_nulls)
@@ -18,9 +18,9 @@ function garrow_list_array_get_value(array, i::gint64)
     ccall((:garrow_list_array_get_value, libarrowglib), Ptr{GArrowArray}, (Ptr{GArrowListArray}, gint64), array, i)
 end
 
-function garrow_struct_array_get_type()
-    ccall((:garrow_struct_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_struct_array_get_type()
+#     ccall((:garrow_struct_array_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_struct_array_new(data_type, length::gint64, children, null_bitmap, n_nulls::gint64)
     ccall((:garrow_struct_array_new, libarrowglib), Ptr{GArrowStructArray}, (Ptr{GArrowDataType}, gint64, Ptr{GList}, Ptr{GArrowBuffer}, gint64), data_type, length, children, null_bitmap, n_nulls)
@@ -38,9 +38,9 @@ function garrow_struct_array_flatten(array, error)
     ccall((:garrow_struct_array_flatten, libarrowglib), Ptr{GList}, (Ptr{GArrowStructArray}, Ptr{Ptr{GError}}), array, error)
 end
 
-function garrow_dictionary_array_get_type()
-    ccall((:garrow_dictionary_array_get_type, libarrowglib), GType, ())
-end
+# function garrow_dictionary_array_get_type()
+#     ccall((:garrow_dictionary_array_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDictionaryArray(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDictionaryArray, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDictionaryArray}},), _ptr)

--- a/src/composite-data-type.jl
+++ b/src/composite-data-type.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_list_data_type_get_type()
-    ccall((:garrow_list_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_list_data_type_get_type()
+#     ccall((:garrow_list_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_list_data_type_new(field)
     ccall((:garrow_list_data_type_new, libarrowglib), Ptr{GArrowListDataType}, (Ptr{GArrowField},), field)
@@ -14,17 +14,17 @@ function garrow_list_data_type_get_value_field(list_data_type)
     ccall((:garrow_list_data_type_get_value_field, libarrowglib), Ptr{GArrowField}, (Ptr{GArrowListDataType},), list_data_type)
 end
 
-function garrow_struct_data_type_get_type()
-    ccall((:garrow_struct_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_struct_data_type_get_type()
+#     ccall((:garrow_struct_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_struct_data_type_new(fields)
     ccall((:garrow_struct_data_type_new, libarrowglib), Ptr{GArrowStructDataType}, (Ptr{GList},), fields)
 end
 
-function garrow_dictionary_data_type_get_type()
-    ccall((:garrow_dictionary_data_type_get_type, libarrowglib), GType, ())
-end
+# function garrow_dictionary_data_type_get_type()
+#     ccall((:garrow_dictionary_data_type_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDictionaryDataType(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDictionaryDataType, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDictionaryDataType}},), _ptr)

--- a/src/compute.jl
+++ b/src/compute.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_cast_options_get_type()
-    ccall((:garrow_cast_options_get_type, libarrowglib), GType, ())
-end
+# function garrow_cast_options_get_type()
+#     ccall((:garrow_cast_options_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowCastOptions(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowCastOptions, libarrowglib), Cvoid, (Ptr{Ptr{GArrowCastOptions}},), _ptr)

--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_decimal128_get_type()
-    ccall((:garrow_decimal128_get_type, libarrowglib), GType, ())
-end
+# function garrow_decimal128_get_type()
+#     ccall((:garrow_decimal128_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowDecimal128(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowDecimal128, libarrowglib), Cvoid, (Ptr{Ptr{GArrowDecimal128}},), _ptr)

--- a/src/enums.jl
+++ b/src/enums.jl
@@ -2,22 +2,22 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_error_get_type()
-    ccall((:garrow_error_get_type, libarrowglib), GType, ())
-end
-
-function garrow_file_mode_get_type()
-    ccall((:garrow_file_mode_get_type, libarrowglib), GType, ())
-end
-
-function garrow_metadata_version_get_type()
-    ccall((:garrow_metadata_version_get_type, libarrowglib), GType, ())
-end
-
-function garrow_type_get_type()
-    ccall((:garrow_type_get_type, libarrowglib), GType, ())
-end
-
-function garrow_time_unit_get_type()
-    ccall((:garrow_time_unit_get_type, libarrowglib), GType, ())
-end
+# function garrow_error_get_type()
+#     ccall((:garrow_error_get_type, libarrowglib), GType, ())
+# end
+#
+# function garrow_file_mode_get_type()
+#     ccall((:garrow_file_mode_get_type, libarrowglib), GType, ())
+# end
+#
+# function garrow_metadata_version_get_type()
+#     ccall((:garrow_metadata_version_get_type, libarrowglib), GType, ())
+# end
+#
+# function garrow_type_get_type()
+#     ccall((:garrow_type_get_type, libarrowglib), GType, ())
+# end
+#
+# function garrow_time_unit_get_type()
+#     ccall((:garrow_time_unit_get_type, libarrowglib), GType, ())
+# end

--- a/src/field.jl
+++ b/src/field.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_field_get_type()
-    ccall((:garrow_field_get_type, libarrowglib), GType, ())
-end
+# function garrow_field_get_type()
+#     ccall((:garrow_field_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_field_new(name, data_type)
     ccall((:garrow_field_new, libarrowglib), Ptr{GArrowField}, (Ptr{gchar}, Ptr{GArrowDataType}), name, data_type)

--- a/src/file.jl
+++ b/src/file.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_file_get_type()
-    ccall((:garrow_file_get_type, libarrowglib), GType, ())
-end
+# function garrow_file_get_type()
+#     ccall((:garrow_file_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_file_close(file, error)
     ccall((:garrow_file_close, libarrowglib), gboolean, (Ptr{GArrowFile}, Ptr{Ptr{GError}}), file, error)

--- a/src/input-stream.jl
+++ b/src/input-stream.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_input_stream_get_type()
-    ccall((:garrow_input_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_input_stream_get_type()
+#     ccall((:garrow_input_stream_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowInputStream(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowInputStream, libarrowglib), Cvoid, (Ptr{Ptr{GArrowInputStream}},), _ptr)
@@ -30,9 +30,9 @@ function GARROW_INPUT_STREAM_GET_CLASS(ptr::gpointer)
     ccall((:GARROW_INPUT_STREAM_GET_CLASS, libarrowglib), Ptr{GArrowInputStreamClass}, (gpointer,), ptr)
 end
 
-function garrow_seekable_input_stream_get_type()
-    ccall((:garrow_seekable_input_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_seekable_input_stream_get_type()
+#     ccall((:garrow_seekable_input_stream_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowSeekableInputStream(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowSeekableInputStream, libarrowglib), Cvoid, (Ptr{Ptr{GArrowSeekableInputStream}},), _ptr)
@@ -74,9 +74,9 @@ function garrow_seekable_input_stream_read_tensor(input_stream, position::gint64
     ccall((:garrow_seekable_input_stream_read_tensor, libarrowglib), Ptr{GArrowTensor}, (Ptr{GArrowSeekableInputStream}, gint64, Ptr{Ptr{GError}}), input_stream, position, error)
 end
 
-function garrow_buffer_input_stream_get_type()
-    ccall((:garrow_buffer_input_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_buffer_input_stream_get_type()
+#     ccall((:garrow_buffer_input_stream_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowBufferInputStream(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowBufferInputStream, libarrowglib), Cvoid, (Ptr{Ptr{GArrowBufferInputStream}},), _ptr)
@@ -110,17 +110,17 @@ function garrow_buffer_input_stream_get_buffer(input_stream)
     ccall((:garrow_buffer_input_stream_get_buffer, libarrowglib), Ptr{GArrowBuffer}, (Ptr{GArrowBufferInputStream},), input_stream)
 end
 
-function garrow_memory_mapped_input_stream_get_type()
-    ccall((:garrow_memory_mapped_input_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_memory_mapped_input_stream_get_type()
+#     ccall((:garrow_memory_mapped_input_stream_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_memory_mapped_input_stream_new(path, error)
     ccall((:garrow_memory_mapped_input_stream_new, libarrowglib), Ptr{GArrowMemoryMappedInputStream}, (Ptr{gchar}, Ptr{Ptr{GError}}), path, error)
 end
 
-function garrow_gio_input_stream_get_type()
-    ccall((:garrow_gio_input_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_gio_input_stream_get_type()
+#     ccall((:garrow_gio_input_stream_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_gio_input_stream_new(gio_input_stream)
     ccall((:garrow_gio_input_stream_new, libarrowglib), Ptr{GArrowGIOInputStream}, (Ptr{GInputStream},), gio_input_stream)

--- a/src/orc-file-reader.jl
+++ b/src/orc-file-reader.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_orc_file_reader_get_type()
-    ccall((:garrow_orc_file_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_orc_file_reader_get_type()
+#     ccall((:garrow_orc_file_reader_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowORCFileReader(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowORCFileReader, libarrowglib), Cvoid, (Ptr{Ptr{GArrowORCFileReader}},), _ptr)

--- a/src/output-stream.jl
+++ b/src/output-stream.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_output_stream_get_type()
-    ccall((:garrow_output_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_output_stream_get_type()
+#     ccall((:garrow_output_stream_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowOutputStream(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowOutputStream, libarrowglib), Cvoid, (Ptr{Ptr{GArrowOutputStream}},), _ptr)
@@ -34,25 +34,25 @@ function garrow_output_stream_write_tensor(stream, tensor, error)
     ccall((:garrow_output_stream_write_tensor, libarrowglib), gint64, (Ptr{GArrowOutputStream}, Ptr{GArrowTensor}, Ptr{Ptr{GError}}), stream, tensor, error)
 end
 
-function garrow_file_output_stream_get_type()
-    ccall((:garrow_file_output_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_file_output_stream_get_type()
+#     ccall((:garrow_file_output_stream_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_file_output_stream_new(path, append::gboolean, error)
     ccall((:garrow_file_output_stream_new, libarrowglib), Ptr{GArrowFileOutputStream}, (Ptr{gchar}, gboolean, Ptr{Ptr{GError}}), path, append, error)
 end
 
-function garrow_buffer_output_stream_get_type()
-    ccall((:garrow_buffer_output_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_buffer_output_stream_get_type()
+#     ccall((:garrow_buffer_output_stream_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_buffer_output_stream_new(buffer)
     ccall((:garrow_buffer_output_stream_new, libarrowglib), Ptr{GArrowBufferOutputStream}, (Ptr{GArrowResizableBuffer},), buffer)
 end
 
-function garrow_gio_output_stream_get_type()
-    ccall((:garrow_gio_output_stream_get_type, libarrowglib), GType, ())
-end
+# function garrow_gio_output_stream_get_type()
+#     ccall((:garrow_gio_output_stream_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_gio_output_stream_new(gio_output_stream)
     ccall((:garrow_gio_output_stream_new, libarrowglib), Ptr{GArrowGIOOutputStream}, (Ptr{GOutputStream},), gio_output_stream)

--- a/src/readable.jl
+++ b/src/readable.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_readable_get_type()
-    ccall((:garrow_readable_get_type, libarrowglib), GType, ())
-end
+# function garrow_readable_get_type()
+#     ccall((:garrow_readable_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_readable_read(readable, n_bytes::gint64, error)
     ccall((:garrow_readable_read, libarrowglib), Ptr{GArrowBuffer}, (Ptr{GArrowReadable}, gint64, Ptr{Ptr{GError}}), readable, n_bytes, error)

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_record_batch_reader_get_type()
-    ccall((:garrow_record_batch_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_reader_get_type()
+#     ccall((:garrow_record_batch_reader_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowRecordBatchReader(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowRecordBatchReader, libarrowglib), Cvoid, (Ptr{Ptr{GArrowRecordBatchReader}},), _ptr)
@@ -46,9 +46,9 @@ function garrow_record_batch_reader_read_next(reader, error)
     ccall((:garrow_record_batch_reader_read_next, libarrowglib), Ptr{GArrowRecordBatch}, (Ptr{GArrowRecordBatchReader}, Ptr{Ptr{GError}}), reader, error)
 end
 
-function garrow_table_batch_reader_get_type()
-    ccall((:garrow_table_batch_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_table_batch_reader_get_type()
+#     ccall((:garrow_table_batch_reader_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowTableBatchReader(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowTableBatchReader, libarrowglib), Cvoid, (Ptr{Ptr{GArrowTableBatchReader}},), _ptr)
@@ -78,17 +78,17 @@ function garrow_table_batch_reader_new(table)
     ccall((:garrow_table_batch_reader_new, libarrowglib), Ptr{GArrowTableBatchReader}, (Ptr{GArrowTable},), table)
 end
 
-function garrow_record_batch_stream_reader_get_type()
-    ccall((:garrow_record_batch_stream_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_stream_reader_get_type()
+#     ccall((:garrow_record_batch_stream_reader_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_stream_reader_new(stream, error)
     ccall((:garrow_record_batch_stream_reader_new, libarrowglib), Ptr{GArrowRecordBatchStreamReader}, (Ptr{GArrowInputStream}, Ptr{Ptr{GError}}), stream, error)
 end
 
-function garrow_record_batch_file_reader_get_type()
-    ccall((:garrow_record_batch_file_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_file_reader_get_type()
+#     ccall((:garrow_record_batch_file_reader_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_file_reader_new(file, error)
     ccall((:garrow_record_batch_file_reader_new, libarrowglib), Ptr{GArrowRecordBatchFileReader}, (Ptr{GArrowSeekableInputStream}, Ptr{Ptr{GError}}), file, error)
@@ -114,9 +114,9 @@ function garrow_record_batch_file_reader_read_record_batch(reader, i::guint, err
     ccall((:garrow_record_batch_file_reader_read_record_batch, libarrowglib), Ptr{GArrowRecordBatch}, (Ptr{GArrowRecordBatchFileReader}, guint, Ptr{Ptr{GError}}), reader, i, error)
 end
 
-function garrow_feather_file_reader_get_type()
-    ccall((:garrow_feather_file_reader_get_type, libarrowglib), GType, ())
-end
+# function garrow_feather_file_reader_get_type()
+#     ccall((:garrow_feather_file_reader_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_feather_file_reader_new(file, error)
     ccall((:garrow_feather_file_reader_new, libarrowglib), Ptr{GArrowFeatherFileReader}, (Ptr{GArrowSeekableInputStream}, Ptr{Ptr{GError}}), file, error)

--- a/src/record-batch.jl
+++ b/src/record-batch.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_record_batch_get_type()
-    ccall((:garrow_record_batch_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_get_type()
+#     ccall((:garrow_record_batch_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_new(schema, n_rows::guint32, columns, error)
     ccall((:garrow_record_batch_new, libarrowglib), Ptr{GArrowRecordBatch}, (Ptr{GArrowSchema}, guint32, Ptr{GList}, Ptr{Ptr{GError}}), schema, n_rows, columns, error)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_schema_get_type()
-    ccall((:garrow_schema_get_type, libarrowglib), GType, ())
-end
+# function garrow_schema_get_type()
+#     ccall((:garrow_schema_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowSchema(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowSchema, libarrowglib), Cvoid, (Ptr{Ptr{GArrowSchema}},), _ptr)

--- a/src/table-builder.jl
+++ b/src/table-builder.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_record_batch_builder_get_type()
-    ccall((:garrow_record_batch_builder_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_builder_get_type()
+#     ccall((:garrow_record_batch_builder_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowRecordBatchBuilder(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowRecordBatchBuilder, libarrowglib), Cvoid, (Ptr{Ptr{GArrowRecordBatchBuilder}},), _ptr)

--- a/src/table.jl
+++ b/src/table.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_table_get_type()
-    ccall((:garrow_table_get_type, libarrowglib), GType, ())
-end
+# function garrow_table_get_type()
+#     ccall((:garrow_table_get_type, libarrowglib), GType, ())
+# end
 
 function glib_autoptr_cleanup_GArrowTable(_ptr)
     ccall((:glib_autoptr_cleanup_GArrowTable, libarrowglib), Cvoid, (Ptr{Ptr{GArrowTable}},), _ptr)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_tensor_get_type()
-    ccall((:garrow_tensor_get_type, libarrowglib), GType, ())
-end
+# function garrow_tensor_get_type()
+#     ccall((:garrow_tensor_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_tensor_new(data_type, data, shape, n_dimensions::gsize, strides, n_strides::gsize, dimention_names, n_dimention_names::gsize)
     ccall((:garrow_tensor_new, libarrowglib), Ptr{GArrowTensor}, (Ptr{GArrowDataType}, Ptr{GArrowBuffer}, Ptr{gint64}, gsize, Ptr{gint64}, gsize, Ptr{Ptr{gchar}}, gsize), data_type, data, shape, n_dimensions, strides, n_strides, dimention_names, n_dimention_names)

--- a/src/writable.jl
+++ b/src/writable.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_writeable_get_type()
-    ccall((:garrow_writeable_get_type, libarrowglib), GType, ())
-end
+# function garrow_writeable_get_type()
+#     ccall((:garrow_writeable_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_writeable_write(writeable, data, n_bytes::gint64, error)
     ccall((:garrow_writeable_write, libarrowglib), gboolean, (Ptr{GArrowWriteable}, Ptr{guint8}, gint64, Ptr{Ptr{GError}}), writeable, data, n_bytes, error)

--- a/src/writeable-file.jl
+++ b/src/writeable-file.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_writeable_file_get_type()
-    ccall((:garrow_writeable_file_get_type, libarrowglib), GType, ())
-end
+# function garrow_writeable_file_get_type()
+#     ccall((:garrow_writeable_file_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_writeable_file_write_at(writeable_file, position::gint64, data, n_bytes::gint64, error)
     ccall((:garrow_writeable_file_write_at, libarrowglib), gboolean, (Ptr{GArrowWriteableFile}, gint64, Ptr{guint8}, gint64, Ptr{Ptr{GError}}), writeable_file, position, data, n_bytes, error)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -2,9 +2,9 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
-function garrow_record_batch_writer_get_type()
-    ccall((:garrow_record_batch_writer_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_writer_get_type()
+#     ccall((:garrow_record_batch_writer_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_writer_write_record_batch(writer, record_batch, error)
     ccall((:garrow_record_batch_writer_write_record_batch, libarrowglib), gboolean, (Ptr{GArrowRecordBatchWriter}, Ptr{GArrowRecordBatch}, Ptr{Ptr{GError}}), writer, record_batch, error)
@@ -18,25 +18,25 @@ function garrow_record_batch_writer_close(writer, error)
     ccall((:garrow_record_batch_writer_close, libarrowglib), gboolean, (Ptr{GArrowRecordBatchWriter}, Ptr{Ptr{GError}}), writer, error)
 end
 
-function garrow_record_batch_stream_writer_get_type()
-    ccall((:garrow_record_batch_stream_writer_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_stream_writer_get_type()
+#     ccall((:garrow_record_batch_stream_writer_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_stream_writer_new(sink, schema, error)
     ccall((:garrow_record_batch_stream_writer_new, libarrowglib), Ptr{GArrowRecordBatchStreamWriter}, (Ptr{GArrowOutputStream}, Ptr{GArrowSchema}, Ptr{Ptr{GError}}), sink, schema, error)
 end
 
-function garrow_record_batch_file_writer_get_type()
-    ccall((:garrow_record_batch_file_writer_get_type, libarrowglib), GType, ())
-end
+# function garrow_record_batch_file_writer_get_type()
+#     ccall((:garrow_record_batch_file_writer_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_record_batch_file_writer_new(sink, schema, error)
     ccall((:garrow_record_batch_file_writer_new, libarrowglib), Ptr{GArrowRecordBatchFileWriter}, (Ptr{GArrowOutputStream}, Ptr{GArrowSchema}, Ptr{Ptr{GError}}), sink, schema, error)
 end
 
-function garrow_feather_file_writer_get_type()
-    ccall((:garrow_feather_file_writer_get_type, libarrowglib), GType, ())
-end
+# function garrow_feather_file_writer_get_type()
+#     ccall((:garrow_feather_file_writer_get_type, libarrowglib), GType, ())
+# end
 
 function garrow_feather_file_writer_new(sink, error)
     ccall((:garrow_feather_file_writer_new, libarrowglib), Ptr{GArrowFeatherFileWriter}, (Ptr{GArrowOutputStream}, Ptr{Ptr{GError}}), sink, error)


### PR DESCRIPTION
Commented out all functions returning GType, as these appear to only be a part of the macro definitions not imported into Julia library. Assumption is that Julia types would provide this information as part of Julia type creation, wouldn't need to use C++ library definitions